### PR TITLE
Fixed cascade deletion problems with accountability tables

### DIFF
--- a/src/compass_app/accountability/tables.py
+++ b/src/compass_app/accountability/tables.py
@@ -29,7 +29,7 @@ class AccountabilityPeriod(SQLModel, table=True):
     goal_channel_id: int | None = Field(sa_type=BigInteger, default=None)
     result_channel_id: int | None = Field(sa_type=BigInteger, default=None)
 
-    entries: list["AccountabilityEntry"] = Relationship(back_populates="period")
+    entries: list["AccountabilityEntry"] = Relationship(back_populates="period", cascade_delete=True)
 
     @classmethod
     def from_week(
@@ -84,17 +84,18 @@ class AccountabilityEntry(AsyncAttrs, SQLModel, table=True):
     __tablename__ = "accountability_entry"
     id: int = Field(primary_key=True)
 
-    user_id: int = Field(foreign_key="compass_user.id")
+    user_id: int = Field(foreign_key="compass_user.id", ondelete="CASCADE")
     user: CompassUser = Relationship() # for now, no back population as we can't go from user to goal
 
-    period_id: int = Field(foreign_key="accountability_period.id")
+    period_id: int = Field(foreign_key="accountability_period.id", ondelete="CASCADE")
     period: AccountabilityPeriod = Relationship(back_populates="entries")
     
     goal_id: int | None = Field(foreign_key="accountability_goal.id", default=None)
-    goal: Optional["AccountabilityGoal"] = Relationship(back_populates="entry")
+    goal: Optional["AccountabilityGoal"] = Relationship(back_populates="entry", cascade_delete=True, sa_relationship_kwargs={"single_parent": True})
+    #                                                                https://docs.sqlalchemy.org/en/20/errors.html#error-bbf0 ^
 
     result_id: int | None = Field(foreign_key="accountability_result.id", default=None)
-    result: Optional["AccountabilityResult"] = Relationship(back_populates="entry")
+    result: Optional["AccountabilityResult"] = Relationship(back_populates="entry", cascade_delete=True, sa_relationship_kwargs={"single_parent": True})
 
     @classmethod
     async def get_or_create(

--- a/src/compass_app/accountability/tables.py
+++ b/src/compass_app/accountability/tables.py
@@ -135,11 +135,11 @@ class AccountabilityResult(SQLModel, table=True):
     __tablename__ = "accountability_result"
     id: int = Field(primary_key=True)
     
-    message_id: int | None = Field(sa_type=BigInteger, default=None, index=True)
+    message_id: int = Field(sa_type=BigInteger, default=None, index=True)
     text: str = ""
-    success_count: int | None = None
-    fail_count: int | None = None
-    date_created: datetime | None = Field(default_factory=lambda: datetime.now(timezone.utc))
+    success_count: int = 0
+    fail_count: int = 0
+    date_created: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     entry: AccountabilityEntry = Relationship(back_populates="result")
 
@@ -155,4 +155,8 @@ class AccountabilityResult(SQLModel, table=True):
 
     @property
     def ratio(self) -> float:
-        return self.success_count / (self.success_count + self.fail_count)
+        return (
+            (self.success_count / (self.success_count + self.fail_count))
+            if self.fail_count > 0 
+            else 0
+        )


### PR DESCRIPTION
Apparently with MariaDB, cascade deletion was enabled implicitly, while with sqlite it needed to be abled explicitly. 

Some 1:1 relationships now use the following:

```
sa_relationship_kwargs={"single_parent": True}
```

Whether that's the right option or not may be debated in the future (see #10)